### PR TITLE
added DoFunc

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package recovery_test
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/lufia/go-recovery"
 )
@@ -35,6 +36,30 @@ func Example_iter() {
 		}
 		return true
 	}, recovery.WithRangeValueParser(parseOptions))
+	// Output:
+	// 0
+	// 1
+	// recovered: panic!
+	// 2
+}
+
+func ExampleDoFunc() {
+	c := make(chan int)
+	var wg sync.WaitGroup
+	wg.Go(recovery.DoFunc(func() {
+		for i := range 3 {
+			c <- i
+		}
+		close(c)
+	}))
+	recovery.ChanIter(c).Range(func(i int) bool {
+		fmt.Println(i)
+		if i == 1 {
+			panic("panic!")
+		}
+		return true
+	}, recovery.WithRangeValueParser(parseOptions))
+	wg.Wait()
 	// Output:
 	// 0
 	// 1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lufia/go-recovery
 
-go 1.20
+go 1.25.0

--- a/recovery.go
+++ b/recovery.go
@@ -7,7 +7,7 @@ func Go(f func(), opts ...Option) {
 	go Recover(f, opts...)
 }
 
-// DoFunc runs f in the current goroutine, returns an func()
+// DoFunc returns a function that invokes f within [Recover].
 // When f panicked, DoFunc recover automatically.
 func DoFunc(f func(), opts ...Option) func() {
 	return func() {

--- a/recovery.go
+++ b/recovery.go
@@ -7,6 +7,14 @@ func Go(f func(), opts ...Option) {
 	go Recover(f, opts...)
 }
 
+// DoFunc runs f in the current goroutine, returns an func()
+// When f panicked, DoFunc recover automatically.
+func DoFunc(f func(), opts ...Option) func() {
+	return func() {
+		Recover(f, opts...)
+	}
+}
+
 // Do runs f in the current goroutine.
 // When f panicked, Do recover automatically.
 func Do(f func(), opts ...Option) {


### PR DESCRIPTION
When using WaitGroup.Go(), the code would look like this:

```go
var wg sync.WaitGroup
wg.Go(func() {
	recovery.Recover(func() {
		...
	}, opts)
})
wg.Wait()
```

In this case, `func() {}` feels redundant. This PR proposes adding a method to improve this issue.

Below suggests examples.
```go
var wg sync.WaitGroup
wg.Go(recovery.DoFunc(func() {
	...
}))
wg.Wait()
```

I would appreciate it if you could incorporate this change.